### PR TITLE
make compatible with more recent numpy versions

### DIFF
--- a/abapy/indentation.py
+++ b/abapy/indentation.py
@@ -191,7 +191,7 @@ def IndentationMesh(Na = 8, Nb = 8, Ns = 4, Nf = 2 , l =1., name = 'CAX4', dtf =
   def PolarTransition(N = 4, radius = 1., theta0 = -90., theta1 = 0., size = None, name = 'CAX4' ):
     mesh = Transition(N = N, name = 'CAX4')
     t0, t1 = radians(theta0), radians(theta1)
-    if size == None: size = (t1-t0 ) * radius /  N 
+    if size is None: size = (t1-t0 ) * radius /  N 
     def dispTrans(x, y, z, labels):
       ux = -x + (radius + 2 * size *  (1-y)) * cos(t0 + (t1-t0) * x)
       uy = -y + (radius + 2 * size *  (1-y)) * sin(t0 + (t1-t0) * x ) 
@@ -206,7 +206,7 @@ def IndentationMesh(Na = 8, Nb = 8, Ns = 4, Nf = 2 , l =1., name = 'CAX4', dtf =
   def PolarShell(radius = 1., N=2 , Ns = 4, theta0 = -90., theta1 = 0., k = None, name = 'CAX4'):
     t0, t1 = radians(theta0), radians(theta1)
     t = (t1-t0)/N
-    if k == None: k = t / (1.- t/2.)
+    if k is None: k = t / (1.- t/2.)
     y1 = [radius]
     for i in xrange(Ns): y1.append(y1[-1] * (k+1))
     y1.reverse()
@@ -1439,14 +1439,14 @@ I_SAMPLE.SURFACE_FACES, I_INDENTER.SURFACE_FACES
 ** STEPS
 **----------------------------------
 '''
-  if sample_mesh == None:
+  if sample_mesh is None:
     sample_mesh =  ParamInfiniteMesh()
-  if indenter == None:
+  if indenter is None:
     indenter = RigidCone2D()
-  if sample_mat == None:
+  if sample_mat is None:
     from materials import VonMises
     sample_mat = VonMises(labels = 'SAMPLE_MAT')
-  if indenter_mat == None:
+  if indenter_mat is None:
     from materials import Elastic
     indenter_mat = Elastic(labels = 'INDENTER_MAT')
   if is_3D:
@@ -1471,7 +1471,7 @@ I_SAMPLE.SURFACE_FACES, I_INDENTER.SURFACE_FACES
     remove_intersection(front_nodes)
   else:
     csys = ''
-  if steps == None:
+  if steps is None:
     steps = [Step(name = 'LOADING', disp = 1.), Step(name = 'UNLOADING', disp = 0.)]
   if isinstance(steps, Step): steps = [steps]
   sample_mat.labels = ['SAMPLE_MAT']
@@ -1527,20 +1527,20 @@ class Manager:
     from materials import Elastic, VonMises
     self.set_workdir(workdir)
     self.set_abqlauncher(abqlauncher)
-    if samplemesh == None: samplemesh = ParamInfiniteMesh()
+    if samplemesh is None: samplemesh = ParamInfiniteMesh()
     self.set_samplemesh(samplemesh)
-    if indenter == None: indenter = RigidCone2D()
+    if indenter is None: indenter = RigidCone2D()
     self.set_indenter(indenter)
-    if samplemat == None:
+    if samplemat is None:
       from abapy.materials import VonMises
       samplemat = VonMises()
-    if indentermat == None:
+    if indentermat is None:
       from abapy.materials import Elastic
       indentermat = Elastic()
     self.set_samplemat(samplemat)
     self.set_indentermat(indentermat)
     self.set_friction(friction)
-    if steps == None: 
+    if steps is None: 
       steps = [Step(name = 'loading', disp = 1.),Step(name = 'unloading', disp = 0.) ]
     self.set_steps(steps)
     self.set_is_3D(is_3D)
@@ -1884,13 +1884,13 @@ class ContactData:
     alt = delete(alt, to_delete, 0)  
     press = delete(press, to_delete, 0) 
     c1, c2 = points[:,0], points[:,1]
-    if delaunay_disp != None:
+    if delaunay_disp is not None:
       c1_temp, c2_temp = copy(c1), copy(c2)
       c1, c2 = delaunay_disp(c1, c2)
         
     points = array([c1, c2]).transpose()        
     conn = Delaunay(points).vertices
-    if delaunay_disp != None: 
+    if delaunay_disp is not None: 
       c1, c2 = c1_temp, c2_temp
       points = array([c1, c2]).transpose()  
     return points, alt, press, conn
@@ -2254,15 +2254,15 @@ class Hertz(object):
     if (a, F, h) == (None, None, None):
       raise ValueError('a, F or h are not define, one at least must be defined')
 
-    if a != None:
+    if a is not None:
       self.a = a
       self.F = self.set_force()
       
-    if F != None and a == None:
+    if F is not None and a is None:
       self.F = F
       self.a = self.set_contact_r()
       
-    if h != None and a == None and F == None:
+    if h is not None and a is None and F is None:
       self.h = h
       self.a = self.set_depth_a()    
       self.F = self.set_depth_F()
@@ -2383,11 +2383,11 @@ class Hanson(object):
  
     if (a, F, h) == (None, None, None):
       raise ValueError('a, F or h are not defined, at least one must be defined')
-    if a != None:
+    if a is not None:
       self.a = a
-    if F != None:
+    if F is not None:
       self.F = F
-    if h != None:
+    if h is not None:
       self.h = h    
     
 

--- a/abapy/materials.py
+++ b/abapy/materials.py
@@ -144,7 +144,7 @@ class DruckerPrager(object):
     beta = float_arg(beta)
     if len(beta) != l: raise Exception, 'Parameters must all have the same length'
     self.beta = array(dtf,beta)
-    if psi == None: psi = beta
+    if psi is None: psi = beta
     psi = float_arg(psi)
     if len(psi) != l: raise Exception, 'Parameters must all have the same length'
     self.psi = array(dtf,psi)

--- a/abapy/mesh.py
+++ b/abapy/mesh.py
@@ -187,14 +187,14 @@ class Nodes(object):
     sets = self.sets
     X, Y, Z = self.x, self.y, self.z
     if len(labels) == 0:
-      if label == None: label = 1
+      if label is None: label = 1
       if label < 1: raise Exception, 'node labels must be > 0.'
       labels.append(label)
       X.append(x)
       Y.append(y)
       Z.append(z)
     else:
-      if label == None: 
+      if label is None: 
         label = max(labels)+1
         labels.append(label)
         X.append(x)
@@ -219,7 +219,7 @@ class Nodes(object):
         else:
           print 'Info: node with label {0} already exists, nothing changed.'.format(label)
           return
-    if toset != None:
+    if toset is not None:
       if type(toset) is str:
         self.add_set(toset,[label])
       else:
@@ -873,7 +873,7 @@ class Mesh(object):
   
   def __init__(self,nodes = None,connectivity=[],space=[],labels=[],name=None, sets={}, surfaces = {}):
     from array import array
-    if nodes == None: nodes = Nodes() 
+    if nodes is None: nodes = Nodes() 
     if isinstance(nodes,Nodes):
       self.nodes = nodes 
       self.dti = nodes.dti
@@ -882,7 +882,7 @@ class Mesh(object):
       dtf = self.dtf
     else:
       raise Exception, 'nodes argument must be a Nodes class instance.'
-    if name == None: name = [None for i in labels]
+    if name is None: name = [None for i in labels]
     self.labels = array(dti,[])
     self.connectivity = []
     self.space = array('H',[])
@@ -908,12 +908,12 @@ class Mesh(object):
     if type(s) in [int, long]:
       labs = [s]
     if type(s) is slice:
-      if s.start != None: 
+      if s.start is not None: 
         start = s.start
       else: 
         start = 1
       stop  = s.stop
-      if s.step != None: 
+      if s.step is not None: 
         step = s.step
       else: 
         step = 1
@@ -1016,7 +1016,7 @@ class Mesh(object):
     dti, dtf = self.dti, self.dtf
     # Input verifications
     connect = array(dti,connectivity)
-    if label == None: 
+    if label is None: 
       if len(self.labels) != 0:
         label = int(max(self.labels)+1)
       else:
@@ -1026,7 +1026,7 @@ class Mesh(object):
     except:
       raise Exception, 'element labels must be int.'
     if space not in [1,2,3]: raise Exception, 'space must be 1,2 or 3'
-    if name == None: name = ''
+    if name is None: name = ''
     if type(name) is not str: raise Exception, 'name type must be str'  
     # inputs processing
     if label in self.labels: 
@@ -1053,7 +1053,7 @@ class Mesh(object):
           self.connectivity.insert(i,connect)
           self.space.insert(i,space)
           self.name.insert(i,name)
-    if toset != None:
+    if toset is not None:
       if type(toset) is str:
         self.add_set(toset,[label])
       else:
@@ -1388,12 +1388,12 @@ class Mesh(object):
               borderEdges.pop(bi(edge))
             if b1 == False: 
               borderEdges.pop(bi(revert))
-    if xmin == None: xmin = min(x)
-    if xmax == None: xmax = max(x)
-    if ymin == None: ymin = min(y)
-    if ymax == None: ymax = max(y)
-    if zmin == None: zmin = min(z)
-    if zmax == None: zmax = max(z)
+    if xmin is None: xmin = min(x)
+    if xmax is None: xmax = max(x)
+    if ymin is None: ymin = min(y)
+    if ymax is None: ymax = max(y)
+    if zmin is None: zmin = min(z)
+    if zmax is None: zmax = max(z)
     
     def test_func(x,y,z):
       '''
@@ -1448,12 +1448,12 @@ class Mesh(object):
           revert = (edge[1],edge[0]) 
           if revert not in borderEdges and edge not in borderEdges:
             borderEdges.append(edge)
-    if xmin == None: xmin = min(x)
-    if xmax == None: xmax = max(x)
-    if ymin == None: ymin = min(y)
-    if ymax == None: ymax = max(y)
-    if zmin == None: zmin = min(z)
-    if zmax == None: zmax = max(z)
+    if xmin is None: xmin = min(x)
+    if xmax is None: xmax = max(x)
+    if ymin is None: ymin = min(y)
+    if ymax is None: ymax = max(y)
+    if zmin is None: zmin = min(z)
+    if zmax is None: zmax = max(z)
     
     def test_func(x,y,z):
       '''
@@ -1720,7 +1720,7 @@ class Mesh(object):
                 oldconn = [oldconn[-1],oldconn[0],oldconn[1],oldconn[2]]
                 nodesOnAxis = get_nodesOnAxis(oldconn)
               newconn = [oldconn[0], layer * nmax  + oldconn[1], (layer+1) * nmax  + oldconn[1], oldconn[3], layer * nmax  + oldconn[2], (layer+1) * nmax  + oldconn[2]] 
-          if newconn != None: 
+          if newconn is not None: 
             name  = te.name[ne]
             if name in mapping.keys():
               name = mapping[name]
@@ -1882,7 +1882,7 @@ class Mesh(object):
       for key in nfields.keys():      
         out += fields[key].dump2vtk(name = key, header = header)
         header = False   
-    if path == None:
+    if path is None:
       return out
     else:
       f = open(path, "wb")
@@ -2102,7 +2102,7 @@ class Mesh(object):
         name = element.name[0]
         self.add_element(label = l + max_elabel, connectivity = conn, space = space, name = name, toset = toset  )
       if simplify:
-        if crit_distance == None:
+        if crit_distance is None:
           self.simplify_nodes()    
         else:
           self.simplify_nodes(crit_distance = crit_distance)
@@ -2368,7 +2368,7 @@ class Mesh(object):
     import matplotlib.collections as collections
     verts = self.faces(use_3D = use_3D)
     if use_3D == False:
-      if face_color == None:
+      if face_color is None:
         patches = collections.LineCollection(verts, 
                             color = edge_color, 
                             linewidth = edge_width) 
@@ -2380,7 +2380,7 @@ class Mesh(object):
                             facecolor = face_color)                      
     else:
       import mpl_toolkits.mplot3d as a3 
-      if face_color == None:
+      if face_color is None:
         patches = a3.art3d.Line3DCollection(verts,
                            edgecolor = edge_color, 
                            linewidth = edge_width)   
@@ -2420,7 +2420,7 @@ class Mesh(object):
     """
     from matplotlib import pyplot as plt
     mesh = copy.copy(self)
-    if disp_func != None: 
+    if disp_func is not None: 
       U = disp_func(mesh.fields)
       mesh.nodes.apply_displacement(U)
     patches = mesh.dump2polygons()
@@ -2428,8 +2428,8 @@ class Mesh(object):
     patches.set_linewidth(edge_width)
     patches.set_edgecolor(edge_color)
     ax.set_aspect("equal")
-    if field_func != None:
-      if cmap == None:
+    if field_func is not None:
+      if cmap is None:
         from matplotlib import cm
         cmap = cm.jet
       X, Y, Z, tri = mesh.dump2triplot()

--- a/abapy/postproc.py
+++ b/abapy/postproc.py
@@ -382,7 +382,7 @@ class HistoryOutput(object):
       start = s.start
       stop  = s.stop
       step  = s.step
-      if step == None: step = 1
+      if step is None: step = 1
       labs = range(start,stop,step)
     if type(s) in [tuple,list, array]:  
       for a in s:
@@ -661,14 +661,14 @@ def GetFieldOutput(odb, step, frame, instance, position, field, subField=None, l
     getLabel = lambda x : x.nodeLabel
     abqPositions = [NODAL, ELEMENT_NODAL]
     positionLabel = 'nodeLabel'
-    if labels == None: labels = [x.label for x in Instance.nodes]
+    if labels is None: labels = [x.label for x in Instance.nodes]
     if type(labels) == str:
       abqNodeSet = odb.rootAssembly.instances[instance].nodeSets[labels].nodes
       labels = array(dti,[ abqNode.label for abqNode in abqNodeSet ])
   if position == 'element': 
     getLabel = lambda x : x.elementLabel
     abqPositions = [WHOLE_ELEMENT, INTEGRATION_POINT]
-    if labels == None: labels = [x.label for x in Instance.elements]
+    if labels is None: labels = [x.label for x in Instance.elements]
     positionLabel = 'elementLabel'
     if type(labels) == str:
       abqElemSet = odb.rootAssembly.instances[instance].elementSets[labels].elements
@@ -681,12 +681,12 @@ def GetFieldOutput(odb, step, frame, instance, position, field, subField=None, l
     if abqloc in abqPositions: matchedPosition = abqloc
   Values = abqFieldOutput.getSubset(region=Instance).getSubset(position = matchedPosition)
   Nvalues = len(Values.values)
-  if subField == None:
+  if subField is None:
     if Values.type == SCALAR:
       scalarValues = Values
     else:
       raise Exception, 'field output is not scalar, maybe because subfield is None.' 
-  if subField != None: 
+  if subField is not None: 
     fieldInvariants = abqFieldOutput.validInvariants # Warning: using getsubset or getscalarfield can lead abaqus to give wrong field invariants or field components. This bug bug seems to be avoided by requestions invariants and components before subseting or scalaring the field.
     fieldComponents = abqFieldOutput.componentLabels  
     for key in fieldComponents:
@@ -936,8 +936,8 @@ def MakeFieldOutputReport(odb, instance, step, frame, report_name, original_posi
   variable = [field]
   variable.append(original_abqposition)
   if type(step) == str: step = odb.steps.keys().index(step) 
-  if sub_field != None:
-    if sub_field_prefix == None:
+  if sub_field is not None:
+    if sub_field_prefix is None:
       prefix = field
     else:
       prefix = sub_field_prefix  
@@ -949,7 +949,7 @@ def MakeFieldOutputReport(odb, instance, step, frame, report_name, original_posi
       sub_field_type = INVARIANT
       sub_field_flag = sub_field
     variable.append( ( (sub_field_type, sub_field_flag) , ) )  
-  if sub_set == None:
+  if sub_set is None:
     leaf = dgo.LeafFromPartInstance(instance)
   else:
     if sub_set_type == 'node':
@@ -1566,8 +1566,8 @@ class FieldOutput(object):
     self.position = position
     self.data = array(dtf,[])
     self.labels = array(dti,[])
-    if data != None:
-      if labels == None:
+    if data is not None:
+      if labels is None:
         labels = range(1,len(data)+1)
       else:
         if len(labels) != len(data) : raise Exception, 'labels and data must have the same length'
@@ -1665,7 +1665,7 @@ class FieldOutput(object):
       start = s.start
       stop  = s.stop
       step  = s.step
-      if step == None: step = 1
+      if step is None: step = 1
       labs = range(start,stop,step)
     if type(s) in [tuple,list, array]:  
       for a in s:
@@ -1721,7 +1721,7 @@ class FieldOutput(object):
     from array import array as a_array
     from numpy import array as n_array
     from numpy import float32, float64, uint16, uint32
-    if other == None : other = 1. 
+    if other is None : other = 1. 
     if isinstance(other,FieldOutput):
       if self.labels != other.labels: raise Exception, 'operands labels must be identicals.'
       if self.position != other.position: raise Exception, 'operands position must be identicals.'
@@ -1969,21 +1969,21 @@ class VectorFieldOutput:
     self.labels = array(dti,[])
     self.data1, self.data2, self.data3 = array(dtf,[]), array(dtf,[]), array(dtf,[])
     data = [data1, data2, data3]
-    isNone = [data1 == None, data2 == None, data3 == None]
+    isNone = [data1 is None, data2 is None, data3 is None]
     for d in data:
-      if (isinstance(d,FieldOutput) == False) and (d != None):
+      if (isinstance(d,FieldOutput) == False) and (d is not None):
         raise Exception, 'data1, data2 and data3 must be FieldOutput instances.'
     
     # Remove comments when python 2.4 is not used anymore
     if isNone != [True, True, True]:
       for i in [2,1,0]:
         d = data[i]
-        if d != None: refData = d
+        if d is not None: refData = d
       labels = refData.labels
       useShortInts = True
       positions = []
       for i in xrange(3):
-        if data[i] == None: data[i] = ZeroFieldOutput_like(refData)
+        if data[i] is None: data[i] = ZeroFieldOutput_like(refData)
         if data[i].labels != labels:
           raise Exception, 'data1, data2 and data3 must be fieldOutputs sharing the same labels.'    
         if data[i].dtf == 'd': self.dtf == 'd'
@@ -2379,19 +2379,19 @@ class TensorFieldOutput:
     self.data11, self.data22, self.data33 = array(dtf,[]), array(dtf,[]), array(dtf,[])
     self.data12, self.data13, self.data23 = array(dtf,[]), array(dtf,[]), array(dtf,[])
     data = [data11, data22, data33, data12, data13, data23]
-    isNone = [data11 == None, data22 == None, data33 == None, data12 == None, data13 == None, data23 == None]
+    isNone = [data11 is None, data22 is None, data33 is None, data12 is None, data13 is None, data23 is None]
     for d in data:
-      if (isinstance(d,FieldOutput) == False) and (d != None):
+      if (isinstance(d,FieldOutput) == False) and (d is not None):
         raise Exception, 'data11, data22, data33, data12, data13 and data23 must be FieldOutput instances.'
     if isNone != [True, True, True, True, True, True]:
       for i in [5,4,3,2,1,0]:
         d = data[i]
-        if d != None: refData = d
+        if d is not None: refData = d
       labels = refData.labels
       useShortInts = True
       positions = []
       for i in xrange(6):
-        if data[i] == None: data[i] = ZeroFieldOutput_like(refData)
+        if data[i] is None: data[i] = ZeroFieldOutput_like(refData)
         if data[i].labels != labels:
           raise Exception, 'data11, data22, data33, data12, data13 and data23 must be fieldOutputs sharing the same labels.'    
         if data[i].dtf == 'd': self.dtf == 'd'


### PR DESCRIPTION
In more recent versions of numpy arrays cannot be interpreted as booleans anymore. Therefore the comparison `== None` is not working anymore. I changed those comparisons to `is None` or `is not None`. Which should also work in older versions and is the recommended way for comparisons with singletons [stackexchange](https://softwareengineering.stackexchange.com/a/322394)